### PR TITLE
Get working with latest GCP k8s

### DIFF
--- a/bin/freshctl
+++ b/bin/freshctl
@@ -118,7 +118,7 @@ function write_pipeline_params() {
   echo "Writing pipeline params yaml"
 
   # Vars we need to add to our kubeconfig
-  SERVER=$(kubectl cluster-info|grep 'Kubernetes master' | awk '{print $NF}')
+  SERVER=$(kubectl cluster-info|grep 'Kubernetes control plane' | awk '{print $NF}')
   NAME=$(kubectl get secrets -n ${APP_NAME} |grep ${APP_NAME}-service-account-token|awk '{print $1}')
   CA=$(kubectl get secret/${NAME} -n ${APP_NAME} -o jsonpath='{.data.ca\.crt}')
   TOKEN=$(kubectl get secret/${NAME} -n ${APP_NAME} -o jsonpath='{.data.token}' | base64 --decode)
@@ -132,14 +132,14 @@ kubeconfig: |
   apiVersion: v1
   kind: Config
   clusters:
-  - name: default-cluster
+  - name: ${K8S_CLUSTER_NAME}
     cluster:
       certificate-authority-data: ${CA}
       server: ${SERVER}
   contexts:
   - name: default-context
     context:
-      cluster: default-cluster
+      cluster: ${K8S_CLUSTER_NAME}
       namespace: default
       user: default-user
   current-context: default-context


### PR DESCRIPTION
Version info:

Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"19+", GitVersion:"v1.19.9-gke.1900", GitCommit:"008fd38bf3dc201bebdd4fe26edf9bf87478309a", GitTreeState:"clean", BuildDate:"2021-04-14T09:22:08Z", GoVersion:"go1.15.8b5", Compiler:"gc", Platform:"linux/amd64"}
WARNING: version difference between client (1.21) and server (1.19) exceeds the supported minor version skew of +/-1

Had hardcoded cluster name, now populates from env.
Also fixed grep for server address.